### PR TITLE
Add system cleanup script explanation to README notebook

### DIFF
--- a/README.ipynb
+++ b/README.ipynb
@@ -287,6 +287,28 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Explicação do script de limpeza do sistema",
+    "",
+    "O script abaixo automatiza a remoção segura de arquivos temporários e logs no Ubuntu. Ele ativa `set -euo pipefail` para interromper a execução em caso de erros ou variáveis não definidas e, em seguida, realiza as seguintes etapas:",
+    "",
+    "1. Remove o conteúdo de `/tmp` e `/var/tmp`.",
+    "2. Limpa o cache do APT com `apt-get clean`.",
+    "3. Trunca arquivos de log principais (como `syslog`, `auth.log` e `kern.log`) em vez de apagá-los.",
+    "4. Exclui logs rotacionados e compactados em `/var/log`.",
+    "5. Reduz o tamanho dos logs do `journalctl` para 500 MB.",
+    "6. Força a rotação de logs com `logrotate`.",
+    "7. Remove arquivos em `~/.cache` e relatórios de falha em `/var/crash`.",
+    "8. Executa `apt-get autoremove` para remover pacotes órfãos.",
+    "9. Esvazia a lixeira do usuário.",
+    "",
+    "Ao final, o script recomenda verificar snapshots antigos do Timeshift, sugere o uso do BleachBit para limpeza gráfica e mostra o espaço ocupado em `/var/log` com `du -sh`.",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "vscode": {
      "languageId": "plaintext"


### PR DESCRIPTION
## Summary
- Document system cleanup bash script in README.ipynb before the references section

## Testing
- `python convert_ipynb_to_md_and_py.py` *(fails: ModuleNotFoundError: No module named 'nbconvert')*

------
https://chatgpt.com/codex/tasks/task_e_68ba4d32b11c8322984c52cd26b258db